### PR TITLE
fix(script): shutdown single server if it's running

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   instance_count = 2
   tags = {
     Project    = "CPEN 431"
-    Assignment = "A7-11"
+    Assignment = "A7-12"
   }
 }
 


### PR DESCRIPTION
The single server previously failed to start on subsequent runs since the prior single server wasn't killed. This is an issue if you changed and uploaded a new JAR you wanted to try for later submissions.